### PR TITLE
ヘッダーのインクルード化 実装完了

### DIFF
--- a/src/main/resources/templates/administrator/insert.html
+++ b/src/main/resources/templates/administrator/insert.html
@@ -17,12 +17,10 @@
 <body>
   <div class="container">
     <!-- 上余白 -->
-    <div class="row">
-      <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
-        <img src="../../static/img/header_logo.png"
-          th:src="@{/img/header_logo.png}">
-      </div>
-    </div>
+    
+    <!-- header_logo.pngのインクルード -->
+    <header th:insert="/common/header::frag_administrator-header"></header>
+    
     <!-- login form -->
     <div class="row">
       <div

--- a/src/main/resources/templates/administrator/login.html
+++ b/src/main/resources/templates/administrator/login.html
@@ -17,12 +17,10 @@
 <body>
   <div class="container">
     <!-- 上余白 -->
-    <div class="row">
-      <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
-        <img src="../../static/img/header_logo.png"
-          th:src="@{/img/header_logo.png}">
-      </div>
-    </div>
+    
+    <!-- header_logo.pngのインクルード -->
+    <header th:insert="/common/header::frag_administrator-header"></header>
+    
     <!-- login form -->
     <div class="row">
       <div

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -1,4 +1,4 @@
-<!-- headerのインクルード -->
+<!-- header縺ｮ繧､繝ｳ繧ｯ繝ｫ繝ｼ繝� -->
 <header th:fragment="frag_employee-header">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle collapsed"
@@ -15,7 +15,7 @@
   </div>
 </header>
 
-<!-- header_logo.pngのインクルード -->
+<!-- header_logo.png縺ｮ繧､繝ｳ繧ｯ繝ｫ繝ｼ繝� -->
 <header th:fragment="frag_administrator-header">
   <div class="row">
       <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
@@ -23,3 +23,4 @@
       </div>
   </div>
 </header>
+

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -1,0 +1,25 @@
+<!-- headerのインクルード -->
+<header th:fragment="frag_employee-header">
+  <div class="navbar-header">
+    <button type="button" class="navbar-toggle collapsed"
+      data-toggle="collapse" data-target="#bs-example-navbar-collapse-1"
+      aria-expanded="false">
+      <span class="sr-only">Toggle navigation</span> <span class="icon-bar"></span>
+      <span class="icon-bar"></span> <span class="icon-bar"></span>
+    </button>
+    <a class="navbar-brand" href="list.html"
+      th:href="@{/employee/showList}"> <img
+      src="../../static/img/header_logo_small.png"
+      th:src="@{/img/header_logo_small.png}">
+    </a>
+  </div>
+</header>
+
+<!-- header_logo.pngのインクルード -->
+<header th:fragment="frag_administrator-header">
+  <div class="row">
+      <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">
+        <img src="../../static/img/header_logo.png" th:src="@{/img/header_logo.png}">
+      </div>
+  </div>
+</header>

--- a/src/main/resources/templates/common/header.html
+++ b/src/main/resources/templates/common/header.html
@@ -1,4 +1,4 @@
-<!-- header縺ｮ繧､繝ｳ繧ｯ繝ｫ繝ｼ繝� -->
+<!-- headerのインクルード -->
 <header th:fragment="frag_employee-header">
   <div class="navbar-header">
     <button type="button" class="navbar-toggle collapsed"
@@ -15,7 +15,7 @@
   </div>
 </header>
 
-<!-- header_logo.png縺ｮ繧､繝ｳ繧ｯ繝ｫ繝ｼ繝� -->
+<!-- header_logo.pngのインクルード -->
 <header th:fragment="frag_administrator-header">
   <div class="row">
       <div class="col-lg-offset-0 col-lg-6 col-md-8 col-sm-10 col-xs-12">

--- a/src/main/resources/templates/employee/detail.html
+++ b/src/main/resources/templates/employee/detail.html
@@ -19,20 +19,9 @@
     <nav class="navbar navbar-default">
       <div class="container-fluid">
         <!-- Brand and toggle get grouped for better mobile display -->
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed"
-            data-toggle="collapse" data-target="#bs-example-navbar-collapse-1"
-            aria-expanded="false">
-            <span class="sr-only">Toggle navigation</span> <span
-              class="icon-bar"></span> <span class="icon-bar"></span> <span
-              class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="list.html"
-            th:href="@{/employee/showList}"> <!-- 企業ロゴ --> <img
-            src="../../static/img/header_logo_small.png"
-            th:src="@{/img/header_logo_small.png}">
-          </a>
-        </div>
+        
+        <!-- headerのインクルード -->
+        <header th:insert="/common/header::frag_employee-header"></header>
 
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse"
@@ -42,8 +31,8 @@
           </ul>
           <p class="navbar-text navbar-right">
             <span th:text="${session.administratorName + 'さん'}">山田さん</span>こんにちは！
-            &nbsp;&nbsp;&nbsp; <a href="../administrator/login.html" th:href="@{/logout}"
-              class="navbar-link">ログアウト</a>
+            &nbsp;&nbsp;&nbsp; <a href="../administrator/login.html"
+              th:href="@{/logout}" class="navbar-link">ログアウト</a>
           </p>
         </div>
         <!-- /.navbar-collapse -->
@@ -68,7 +57,8 @@
           <!-- ここから上を編集する必要はありません -->
 
           <!-- ここにモックのform要素を貼り付けます -->
-          <form method="post" action="list.html" th:action="@{/employee/update}" th:object="${updateEmployeeForm}">
+          <form method="post" action="list.html"
+            th:action="@{/employee/update}" th:object="${updateEmployeeForm}">
             <fieldset>
               <legend>従業員情報</legend>
               <table class="table table-striped">

--- a/src/main/resources/templates/employee/list.html
+++ b/src/main/resources/templates/employee/list.html
@@ -19,20 +19,9 @@
     <nav class="navbar navbar-default">
       <div class="container-fluid">
         <!-- Brand and toggle get grouped for better mobile display -->
-        <div class="navbar-header">
-          <button type="button" class="navbar-toggle collapsed"
-            data-toggle="collapse" data-target="#bs-example-navbar-collapse-1"
-            aria-expanded="false">
-            <span class="sr-only">Toggle navigation</span> <span
-              class="icon-bar"></span> <span class="icon-bar"></span> <span
-              class="icon-bar"></span>
-          </button>
-          <a class="navbar-brand" href="list.html"
-            th:href="@{/employee/showList}"> <!-- 企業ロゴ --> <img
-            src="../../static/img/header_logo_small.png"
-            th:src="@{/img/header_logo_small.png}">
-          </a>
-        </div>
+        
+        <!-- headerのインクルード -->
+        <header th:insert="/common/header::frag_employee-header"></header>
 
         <!-- Collect the nav links, forms, and other content for toggling -->
         <div class="collapse navbar-collapse"


### PR DESCRIPTION
ヘッダーのインクルード化の実装が完了しました。
共通部分（ヘッダー）を/common/header.htmlに置き、フラグメントでインクルードしました。
branch:  feature/include-header-footer